### PR TITLE
Fix crash on paths with spaces

### DIFF
--- a/src/integration/integration.ts
+++ b/src/integration/integration.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { AstroIntegration, AstroIntegrationLogger } from "astro";
 import fg from "fast-glob";
 import fs from "fs-extra";
@@ -50,9 +51,7 @@ export function i18n(userI18nConfig: UserI18nConfig): AstroIntegration {
           order: "pre",
         });
 
-        const configSrcDirPathname = path.normalize(
-          removeLeadingForwardSlashWindows(config.srcDir.pathname)
-        );
+        const configSrcDirPathname = fileURLToPath(config.srcDir);
 
         let included: string[] = ensureGlobsHaveConfigSrcDirPathname(
           typeof include === "string" ? [include] : include,


### PR DESCRIPTION
Fixes #5 (possibly #4)

The bug was a very simple albeit vexing one, hard to replicate: it only affected situations in which the absolute path to the pages directory had spaces in them.

Previously, converting the `srcDir` ( a file URL) attribute of the `config` object was converted as follows:

https://github.com/jlarmstrongiv/astro-i18n-aut/blob/572832d1dd713d87c5d0d02444bfac9285dd803c/src/integration/integration.ts#L53-L55

The pathname, however, does not convert URL escape sequences like `%20` (a space) to their respective characters, leading to an error when copying the files to the temporary directory.

My solution is to use the `fileURLToPath` method of the `URL` module. This also removes the calls to `path.normalize` and the astro internal helper `removeLeadingForwardSlashWindows`, but it seems `fileURLToPath` fixes any cross-platform discrepancies automatically.