### PR TITLE
Allow Astro 5.0.0-beta as Peer Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "astro": "^4.0.3",
+    "astro": "^4.0.3 || >=5.0.0-beta",
     "kleur": "^4.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "dist"
   ],
   "scripts": {
+    "prepare": "npm run build",
     "build": "tsup-node",
     "watch": "tsup-node --watch"
   },


### PR DESCRIPTION
- Updated package.json to allow both astro ^4.0.3 and >=5.0.0-beta as peer dependencies so users don't have to do `--legacy-peer-deps` when installing packages.
- This ensures compatibility with the latest beta version of Astro.